### PR TITLE
Revert "Uses only one port"

### DIFF
--- a/tunnel-server/Proxy2Client_com.js
+++ b/tunnel-server/Proxy2Client_com.js
@@ -30,7 +30,7 @@ function ProxyServer(httpport,websocketport,serversocketport){
   MessageProxy.call(this,function(message,ws){
     that.ws[message.id].send(JSON.stringify(message));
   },function(message,con){
-    con.send(JSON.stringify(message)+"\u00B6")
+    con.write(JSON.stringify(message)+"\u00B6")
   })
   this.locals = {};
   this.users = {};
@@ -64,7 +64,7 @@ function ProxyServer(httpport,websocketport,serversocketport){
 
 
   this.wss.on('connection', function (ws) {
-    console.log('ws connection');
+
     ws.on('close',function(){
       console.log("disconnect");
       /*
@@ -85,22 +85,9 @@ function ProxyServer(httpport,websocketport,serversocketport){
       }catch(e){
         return ws.close();
       }
-      if(message.cmd && message.cmd === "remoteTunnel-add"){
-        that.slaveEnter(ws);
-        ws.removeAllListeners("message");
-        ws.removeAllListeners("close");
-        ws.on('close', function () {
-          that.slaveLeave(ws);
-        });
-        ws.on('message', function (data) {
-          that.handleSocketMessage(data, ws);
-        })
-
-      } else {
-        message.protocol = "ws";
-        that.ws[message.id] = ws;
-        that.clientMessage(message,ws);
-      }
+      message.protocol = "ws";
+      that.ws[message.id] = ws;
+      that.clientMessage(message,ws);
     });
   });
 


### PR DESCRIPTION
My last commit in #1 didn't remove the need for the other port.  Maybe a route could be added to the [sheild](https://github.com/formula1/Silk-Server/blob/master/tunnel-server/Proxy2Client_com.js#L203) instead of using the [server](https://github.com/formula1/Silk-Server/blob/master/tunnel-server/Proxy2Client_com.js#L107) for starting the tunnel.  I probably won't have time to work on this for a couple weeks.  Trying to get the next version of Silk done.

This reverts commit e41b2735deb8ec91c6eb076aeed0079fbf5d90d0.
